### PR TITLE
Update ZipRepository.php

### DIFF
--- a/src/Chumper/Zipper/Repositories/ZipRepository.php
+++ b/src/Chumper/Zipper/Repositories/ZipRepository.php
@@ -7,6 +7,18 @@ class ZipRepository implements RepositoryInterface
 {
     private $archive;
 
+    /*
+     * Edited By renanpro03
+     */
+
+    /**
+     * @return null|ZipArchive
+     */
+    public function getArchive()
+    {
+        return $this->archive;
+    }
+
     /**
      * Construct with a given path
      *


### PR DESCRIPTION
Implemented Getter for Archive property, necessary to access the data object returned after ZIP file generation.
Example:

$zip = Zipper::make(storage_path($this->getPath()))->add($filesPath);

dd($batch->getRepository()->getArchive() ->numFiles);
